### PR TITLE
Update to 0.6 to fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,8 +164,8 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.5.0"
-source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#5b7f1cc5de6d9664ee30e7d6a2f183499de0f685"
+version = "0.6.0"
+source = "git+https://github.com/cloud-hypervisor/kvm-ioctls?branch=ch#b7f21758bf8e46ac55a28a1b2ed008b5732bbb44"
 dependencies = [
  "kvm-bindings",
  "libc",


### PR DESCRIPTION
Update kvm-ioctls version to 0.6

Unfortunately the 0.5 branch of kvm-ioctls package is now missing
a reference on a dependency; let's bump to 0.6.0.

Fixes: vhost-user-vsock #2
   
Signed-off-by: Kushal Kothari < kushalkothari285@gmail.com >